### PR TITLE
support `log.warn()` and `log.warning()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,13 @@ var debug = require('debug')('blocked-stats');
 
 module.exports = function(log, stats){
   var msg = 'Event loop blocked';
+  // support both `log.warn()` and `log.warning()`, as our ecs-log-js uses `.warning()`
+  // TODO: emit events rather than requiring "log" and "stats" interfaces
+  var warn = (log.warn || log.warning).bind(log)
   blocked(function(ms){
     stats.histogram('event-loop-blocked', ms)
     if (ms > 10000) log.error(msg, { ms: ms })
-    else if (ms > 1000) log.warn(msg, { ms: ms })
+    else if (ms > 1000) warn(msg, { ms: ms })
     else if (ms > 100) debug('Event loop blocked for %sms', ms | 0);
   });
 };


### PR DESCRIPTION
Our `ecs-logs-js` thing doesn't support `log.warn()`.

@segmentio/site 